### PR TITLE
Define previousprops.current and mounted whether or not a didMount ha…

### DIFF
--- a/src/enhancers/withLifecycle.js
+++ b/src/enhancers/withLifecycle.js
@@ -38,10 +38,10 @@ export default (lifecycle = {}) => ({generateNewVariable}) => {
       useEffect(function () {
         if (didMount) {
           didMount(${PROPS});
-
-          mounted.current = true;
-          previousProps.current = ${PROPS};
         }
+
+        mounted.current = true;
+        previousProps.current = ${PROPS};
 
         if (willUnmount) {
           return function () {


### PR DESCRIPTION
…ndler is specified.

I had an issue in our project where we were calling `componentWillUnmount` but we didn't define `componentDidMount`, so props were never passed to the unmount handler.

This fix makes sense to me but I'm not sure if defining mounted and previousProps has any other side effects. Thoughts?